### PR TITLE
Fixed syntax for `not` and `and`

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -225,7 +225,7 @@ function DigitalClock:setupAutoRefreshTime()
                 batt_lvl = main_batt_lvl
             end
 
-            if !is_charging && batt_lvl < 20 then
+            if not is_charging and batt_lvl < 20 then
                 self.bat_info_msg = InfoMessage:new{
                     text = T("Please recharge your device. Battery level: %1%", batt_lvl)
                 }


### PR DESCRIPTION
This commit was done directly on the web interface, using a smartphone. Be aware it might be wrong.