### PR TITLE
Use generic pause auto suspend for Kindle

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -86,20 +86,16 @@ function DigitalClock:_getFileName()
 end
 
 function DigitalClock:_pauseAutoSuspend()
-    if Device:isCervantes() or Device:isKobo() then
+    if Device:isCervantes() or Device:isKobo() or Device:isKindle() then
         PluginShare.pause_auto_suspend = true
-    elseif Device:isKindle() then
-        os.execute("lipc-set-prop com.lab126.powerd preventScreenSaver 1")
     else
         logger.warn("pause suspend not supported on this device")
     end
 end
 
 function DigitalClock:_startAutoSuspend()
-    if Device:isCervantes() or Device:isKobo() then
+    if Device:isCervantes() or Device:isKobo() or Device:isKindle() then
         PluginShare.pause_auto_suspend = false
-    elseif Device:isKindle() then
-        os.execute("lipc-set-prop com.lab126.powerd preventScreenSaver 0")
     else
         logger.warn("pause suspend not supported on this device")
     end


### PR DESCRIPTION
Attempt to fix #7 

Use the generic pause auto suspend method instead of the specific hacky one for Kindle. keepalive.koplugin has specific code to handle Kindle so maybe it works better that way.